### PR TITLE
fix waveflow

### DIFF
--- a/waveflow/config.py
+++ b/waveflow/config.py
@@ -4,7 +4,7 @@ _C = CN()
 _C.data = CN(
     dict(
         batch_size=8, # batch size
-        valid_size=64, # the first N examples are reserved for validation
+        valid_size=16, # the first N examples are reserved for validation
         sample_rate=22050, # Hz, sample rate
         n_fft=1024, # fft frame size
         win_length=1024, # window size

--- a/waveflow/train.py
+++ b/waveflow/train.py
@@ -70,7 +70,7 @@ class Experiment(ExperimentBase):
 
         valid_batch_fn = LJSpeechCollector()
         valid_loader = DataLoader(
-            valid_set, batch_size=config.data.batch_size, collate_fn=valid_batch_fn)
+            valid_set, batch_size=1, collate_fn=valid_batch_fn)
         
         self.train_loader = train_loader
         self.valid_loader = valid_loader


### PR DESCRIPTION
1.  change default config: use 16 sentences for validation;
2. always use batch_size=1 for validation to ensure a correct validation loss.